### PR TITLE
Add another step in Moosh playbook to set capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Le playbook définit les principales étapes d'une [installation Moodle](https:/
 
 ## Configuration automatique post-installation
 
-La plupart des options de configuration ne deviennent disponibles qu'une fois l'installation initiale terminée (étape ci-dessus). Pour la configuration standard de la PAD+, il est possible de scripter ces options dans le [fichier pad_config_vars.yml](./ansible-playbooks/vars/pad_config_vars.yml) avec le playbook `ansible_playbooks/moosh_config_set.yml`. La procédure utilise l'outil [Moosh](https://moosh-online.com/) (installé par le paybook).
+La plupart des options de configuration ne deviennent disponibles qu'une fois l'installation initiale terminée (étape ci-dessus). Pour la configuration standard de la PAD+, il est possible de scripter ces options dans le [fichier pad_config_vars.yml](./ansible-playbooks/vars/pad_config_vars.yml) avec le playbook `ansible_playbooks/moosh_config_set.yml`. La procédure utilise l'outil [Moosh](https://moosh-online.com/) (installé par le playbook). Le playbook prend aussi en charge la redéfinition des permissions des rôles.
 
 ```
 ansible-playbook moosh_config_set.yml -i eig-epshad.hosts.yml -u root
@@ -68,6 +68,7 @@ ansible-playbook moosh_config_set.yml -i eig-epshad.hosts.yml -u root
 
 Cela permet par exemple de configurer le fuseau horaire, activer la recherche globale,... Voir une liste (non exhaustive) de [paramètres Moodle sous Moosh](./moosh-config.md).
 
+Dans le fichier `pad_config_vars.yml`, la seconde section `capabilities` permet de changer les permissions de la plateforme par rôle. Par exemple, désactiver l'édition du tableau de bord pour tous les utilisateurs.
 
 ## MariaDB et Debian 9
 

--- a/ansible-playbooks/moosh_config_set.yml
+++ b/ansible-playbooks/moosh_config_set.yml
@@ -51,3 +51,11 @@
       args:
         chdir: "{{ moodle_path }}"
       loop: "{{ config }}"
+
+    - name: Set capabilities with Moosh
+      ansible.builtin.shell: >
+        sudo -u {{ webserver.webuser }}
+        moosh role-update-capability {{ item.role }} {{ item.capability }} {{ item.value }} {{ item.contextid | default(1) }}
+      args:
+        chdir: "{{ moodle_path }}"
+      loop: "{{ capabilities }}"

--- a/ansible-playbooks/vars/pad_config_vars.yml
+++ b/ansible-playbooks/vars/pad_config_vars.yml
@@ -43,3 +43,13 @@ config:
       accessibility = accessibilitychecker, accessibilityhelper
       other = html
     plugin: editor_atto
+capabilities:
+  # -
+  #   role: role short name (see moosh role-list)
+  #   capability: capability key
+  #   value: inherit|allow|prevent|prohibit
+  #   contexid: (optional, default 1 = system-wide)
+- # prevent all users to modify their dashboard (except admin)
+  role: user
+  capability: moodle/my:manageblocks
+  value: inherit


### PR DESCRIPTION
- use moosh role-update-capability command
- setup another list 'capabilities' in pad_config_vars to define new permissions
- disable my:manageblocks for all users (dashboard edition)